### PR TITLE
bump to 1.2.4

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,9 @@
 
+1.2.4 / 2014-05-04
+==================
+
+ * named generator function for improved debugging. Closes #7
+
 1.2.3 / 2014-02-27
 ==================
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "koa-etag",
   "description": "ETag support for koa",
   "repository": "koajs/etag",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "keywords": [
     "koa",
     "middleware",


### PR DESCRIPTION
Out of sync with npmjs.org `koa-etag`.
