### PR TITLE
Safer stream handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,12 +39,10 @@ function etag() {
     // hash
     if (body instanceof Stream) {
       if (!body.path) return;
-      try {
-        var s = yield stat(body.path);
-        etag = crc(s.size + '.' + s.mtime);
-      } catch (e) {
-        console.log(e.stack || e);
-      }
+      var isExists = yield exists(body.path);
+      if (!isExists) return;
+      var s = yield stat(body.path);
+      etag = crc(s.size + '.' + s.mtime);
     } else if ('string' == type || Buffer.isBuffer(body)) {
       etag = crc(body);
     } else {
@@ -63,5 +61,11 @@ function etag() {
 function stat(file) {
   return function(done){
     fs.stat(file, done);
+  }
+}
+
+function exists(file) {
+  return function(done){
+    fs.exists(file, done);
   }
 }


### PR DESCRIPTION
for example [`request`](https://github.com/mikeal/request) returns a stream that has a `path` attribute (the path on the server) but will cause `stat` to fail and throw.
