### PR TITLE
When Etag matches If-None-Match, the server should return 304

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,17 @@ function etag(options) {
     }
 
     // add etag
-    if (etag) this.set('ETag', '"' + etag + '"');
+    if (etag) {
+      etag = '"' + etag + '"';
+      this.set('ETag', etag);
+
+      // return 304 if etag matches
+      var match = this.get('If-None-Match');
+      if (etag === match) {
+        this.status = 304;
+        this.body = '';
+      }
+    }
   }
 }
 


### PR DESCRIPTION
> If the ETag values match, meaning that the resource has not changed, then the server may send back a very short response with an HTTP 304 Not Modified status. The 304 status tells the client that its cached version is still good and that it should use that.

via http://en.wikipedia.org/wiki/HTTP_ETag
