### PR TITLE
remove unused argument for getResponseEntity

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function etag(options) {
   };
 }
 
-function getResponseEntity(ctx, options) {
+function getResponseEntity(ctx) {
   // no body
   var body = ctx.body;
   if (!body || ctx.response.get('ETag')) return;


### PR DESCRIPTION
function of "getResponseEntity" not used options now.
it makes me confused.